### PR TITLE
Improves time to subset train data

### DIFF
--- a/data/GDELT/get_history_graph.py
+++ b/data/GDELT/get_history_graph.py
@@ -74,8 +74,9 @@ def load_quadruples(inPath, fileName, fileName2=None):
 
 
 def get_data_with_t(data, tim):
-    triples = [[quad[0], quad[1], quad[2]] for quad in data if quad[3] == tim]
-    return np.array(triples)
+    x = data[np.where(data[3] == tim)].copy()
+    x = np.delete(x, 3, 1) # drops 3rd column
+    return x
 
 
 def comp_deg_norm(g):

--- a/data/ICEWS14/get_history_graph.py
+++ b/data/ICEWS14/get_history_graph.py
@@ -74,8 +74,9 @@ def load_quadruples(inPath, fileName, fileName2=None):
 
 
 def get_data_with_t(data, tim):
-    triples = [[quad[0], quad[1], quad[2]] for quad in data if quad[3] == tim]
-    return np.array(triples)
+    x = data[np.where(data[3] == tim)].copy()
+    x = np.delete(x, 3, 1) # drops 3rd column
+    return x
 
 
 def comp_deg_norm(g):

--- a/data/ICEWS18/get_history_graph.py
+++ b/data/ICEWS18/get_history_graph.py
@@ -74,8 +74,9 @@ def load_quadruples(inPath, fileName, fileName2=None):
 
 
 def get_data_with_t(data, tim):
-    triples = [[quad[0], quad[1], quad[2]] for quad in data if quad[3] == tim]
-    return np.array(triples)
+    x = data[np.where(data[3] == tim)].copy()
+    x = np.delete(x, 3, 1) # drops 3rd column
+    return x
 
 
 def comp_deg_norm(g):

--- a/data/WIKI/get_history_graph.py
+++ b/data/WIKI/get_history_graph.py
@@ -74,8 +74,9 @@ def load_quadruples(inPath, fileName, fileName2=None):
 
 
 def get_data_with_t(data, tim):
-    triples = [[quad[0], quad[1], quad[2]] for quad in data if quad[3] == tim]
-    return np.array(triples)
+    x = data[np.where(data[3] == tim)].copy()
+    x = np.delete(x, 3, 1) # drops 3rd column
+    return x
 
 
 def comp_deg_norm(g):

--- a/data/YAGO/get_history_graph.py
+++ b/data/YAGO/get_history_graph.py
@@ -74,8 +74,9 @@ def load_quadruples(inPath, fileName, fileName2=None):
 
 
 def get_data_with_t(data, tim):
-    triples = [[quad[0], quad[1], quad[2]] for quad in data if quad[3] == tim]
-    return np.array(triples)
+    x = data[np.where(data[3] == tim)].copy()
+    x = np.delete(x, 3, 1) # drops 3rd column
+    return x
 
 
 def comp_deg_norm(g):


### PR DESCRIPTION
Using `np.where` significantly reduces the time to subset training data. This is in opposition to using inline for-loops to perform the subset operation.